### PR TITLE
Stop operation should now include the localIdentifier in the command,…

### DIFF
--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -68,6 +68,7 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
     public void stop() throws Exception {
         Map<String, String> localOptions = new HashMap<String, String>();
         localOptions.put("key", accesskey);
+        localOptions.put("localIdentifier", localIdentifier);
         if (binarypath != null && binarypath.length() > 0) localOptions.put("binarypath", binarypath);
         super.stop(localOptions);
     }


### PR DESCRIPTION
… as well, so as to not stop ALL instances of BrowserstackLocal running with the same key.

A simple use case that demonstrates that this is an issue, is having two Jenkins' jobs using Browserstack with same key concurrently. When the first job finishes executing, it will terminate all instances of BrowserstackLocal on the machine using the same key, therefore breaking the execution of the second job.

P.S.: I tried creating an issue for this but "Human verification", etc... So I'm still waiting for approval.