### PR TITLE
Replace all invalid characters in local identifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <java.level>6</java.level>
         <java.level.test>6</java.level.test>
         <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
+        <junit-quickcheck.version>0.8</junit-quickcheck.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- This is the testing Tracking Id. If you want to build the project for production, please use the
@@ -109,6 +110,25 @@
             <artifactId>junit</artifactId>
             <version>4.11</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.9.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-core</artifactId>
+            <version>${junit-quickcheck.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-generators</artifactId>
+            <version>${junit-quickcheck.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -51,7 +51,7 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
             arguments.add(args[i]);
         }
 
-        localIdentifier = (UUID.randomUUID().toString() + "-" + buildTag).replaceAll("[^a-bA-Z0-9_\\-\\.]", "_");
+        localIdentifier = UUID.randomUUID().toString() + "-" + buildTag.replaceAll("[^\\w\\-\\.]", "_");
 
         arguments.add(localIdPos, localIdentifier);
         arguments.add(localIdPos, "-" + OPTION_LOCAL_IDENTIFIER);

--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -51,7 +51,7 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
             arguments.add(args[i]);
         }
 
-        localIdentifier = UUID.randomUUID().toString().replaceAll("\\-", "") + "-" + buildTag.replaceAll("\\s","").replaceAll("#", "_");
+        localIdentifier = (UUID.randomUUID().toString() + "-" + buildTag).replaceAll("[^a-bA-Z0-9_\\-\\.]", "_");
 
         arguments.add(localIdPos, localIdentifier);
         arguments.add(localIdPos, "-" + OPTION_LOCAL_IDENTIFIER);

--- a/src/test/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocalTest.java
+++ b/src/test/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocalTest.java
@@ -1,0 +1,24 @@
+package com.browserstack.automate.ci.jenkins.local;
+
+import org.junit.runner.RunWith;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@RunWith(JUnitQuickcheck.class)
+public class JenkinsBrowserStackLocalTest {
+
+    public final String ACCESS_KEY = "dummy";
+
+    @Property
+    public void testLocalIdentifierGeneration(String buildTag) {
+        LocalConfig localConfig = new LocalConfig();
+        JenkinsBrowserStackLocal jenkinsBSLocal = new JenkinsBrowserStackLocal(ACCESS_KEY, localConfig, buildTag);
+
+        String localIdentifier = jenkinsBSLocal.getLocalIdentifier();
+
+        assertThat(localIdentifier).matches("^[a-zA-Z0-9_\\-\\.]+$");
+    }
+
+}


### PR DESCRIPTION
The `buildTag` used in the local identifier passed to BrowserStack can contain invalid characters, particularly if the job is in a folder. The current implementation replaces specific characters, which misses all other invalid ones.

This change replaces any characters which don't match the set of valid identifiers, obtained from the error message which prompted the bug report:

> identifier can only have alphanumeric characthers with combination of hiphen(-), underscore(_) and dot(.)