### PR TITLE
Environment variables in local options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ hs_err_pid*
 .classpath
 .project
 .settings/
+/bin/

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackBuildWrapper.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackBuildWrapper.java
@@ -11,6 +11,7 @@ import com.browserstack.automate.ci.common.analytics.Analytics;
 import com.browserstack.automate.ci.jenkins.local.BrowserStackLocalUtils;
 import com.browserstack.automate.ci.jenkins.local.JenkinsBrowserStackLocal;
 import com.browserstack.automate.ci.jenkins.local.LocalConfig;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractItem;
@@ -60,7 +61,7 @@ public class BrowserStackBuildWrapper extends BuildWrapper {
     AutomateBuildEnvironment buildEnv = new AutomateBuildEnvironment(credentials, launcher, logger);
     if (accesskey != null && this.localConfig != null) {
       try {
-        buildEnv.startBrowserStackLocal(build.getFullDisplayName());
+        buildEnv.startBrowserStackLocal(build.getFullDisplayName(), build.getEnvironment(listener));
       } catch (Exception e) {
         listener.fatalError(e.getMessage());
         throw new IOException(e.getCause());
@@ -119,8 +120,8 @@ public class BrowserStackBuildWrapper extends BuildWrapper {
       super.buildEnvVars(env);
     }
 
-    public void startBrowserStackLocal(String buildTag) throws Exception {
-      browserstackLocal = new JenkinsBrowserStackLocal(accesskey, localConfig, buildTag);
+    public void startBrowserStackLocal(String buildTag, EnvVars envVars) throws Exception {
+      browserstackLocal = new JenkinsBrowserStackLocal(accesskey, localConfig, buildTag, envVars, logger);
       log(logger, "Local: Starting BrowserStack Local...");
       browserstackLocal.start(launcher);
       log(logger, "Local: Started");

--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -41,6 +41,7 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
     private String[] processLocalArguments(final String argString, String buildTag) {
         String[] args = argString.split("\\s+");
         int localIdPos = 0;
+        boolean localIdentifierOverriden = false;
         List<String> arguments = new ArrayList<String>();
         for (int i = 0; i < args.length; i++) {
             if (args[i].contains(OPTION_LOCAL_IDENTIFIER) || args[i].contains(OPTION_LOCAL_IDENTIFIER_2)) {
@@ -48,7 +49,8 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
                 if (i < args.length - 1 && args[i + 1] != null && !args[i + 1].startsWith("-")) {
                     localIdentifier = args[i + 1];
                     if (StringUtils.isNotBlank(localIdentifier)) {
-                        return args;
+                        localIdentifierOverriden = true;
+                        continue;
                     }
 
                     // skip next, since already processed
@@ -68,11 +70,11 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
 
             arguments.add(args[i]);
         }
-
-        localIdentifier = UUID.randomUUID().toString() + "-" + buildTag.replaceAll("[^\\w\\-\\.]", "_");
-
-        arguments.add(localIdPos, localIdentifier);
-        arguments.add(localIdPos, "-" + OPTION_LOCAL_IDENTIFIER);
+        if (!localIdentifierOverriden) {
+          localIdentifier = UUID.randomUUID().toString() + "-" + buildTag.replaceAll("[^\\w\\-\\.]", "_");
+          arguments.add(localIdPos, localIdentifier);
+          arguments.add(localIdPos, "-" + OPTION_LOCAL_IDENTIFIER);
+        }
         return arguments.toArray(new String[]{});
     }
 

--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public class JenkinsBrowserStackLocal extends Local implements Serializable {
+    private static final long serialVersionUID = 1830651088511115761L;
     private static final String OPTION_LOCAL_IDENTIFIER = "localIdentifier";
     // local identifier doesn't override when user passes --local-identifier
     // Not replacing existing localIdentifier because of legacy reason 
@@ -131,7 +132,9 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
     }
 
     public String[] getArguments() {
-        return arguments;
+      // using clone()  here because without it findbugs raises EI_EXPOSE_REP.
+      // https://stackoverflow.com/a/1732803/2577465
+      return arguments.clone();
     }
 
     private static DaemonAction detectDaemonAction(List<String> command) {

--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -15,6 +15,9 @@ import java.util.UUID;
 
 public class JenkinsBrowserStackLocal extends Local implements Serializable {
     private static final String OPTION_LOCAL_IDENTIFIER = "localIdentifier";
+    // local identifier doesn't override when user passes --local-identifier
+    // Not replacing existing localIdentifier because of legacy reason 
+    private static final String OPTION_LOCAL_IDENTIFIER_2 = "--local-identifier";
 
     private final String accesskey;
     private final String binarypath;
@@ -33,7 +36,7 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
         int localIdPos = 0;
         List<String> arguments = new ArrayList<String>();
         for (int i = 0; i < args.length; i++) {
-            if (args[i].contains(OPTION_LOCAL_IDENTIFIER)) {
+            if (args[i].contains(OPTION_LOCAL_IDENTIFIER) || args[i].contains(OPTION_LOCAL_IDENTIFIER_2)) {
                 localIdPos = i;
                 if (i < args.length - 1 && args[i + 1] != null && !args[i + 1].startsWith("-")) {
                     localIdentifier = args[i + 1];

--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -27,7 +27,7 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
     private final String[] arguments;
     private String localIdentifier;
     private EnvVars envVars;
-    private PrintStream logger;
+    private transient PrintStream logger; // transient since PrintStream is no serializable, it breaks in PipeLine tests 
 
     public JenkinsBrowserStackLocal(String accesskey, LocalConfig localConfig, String buildTag, EnvVars envVars, PrintStream logger) {
         this.accesskey = accesskey;
@@ -126,6 +126,10 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
 
     public String getLocalIdentifier() {
         return localIdentifier;
+    }
+
+    public String[] getArguments() {
+        return arguments;
     }
 
     private static DaemonAction detectDaemonAction(List<String> command) {

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -63,7 +63,7 @@ public class BrowserStackPipelineStepExecution extends SynchronousNonBlockingSte
     if (accessKey != null && this.localConfig != null) {
       try {
         startBrowserStackLocal(run.getFullDisplayName(), taskListener.getLogger(), accessKey,
-            launcher, run.getEnvironment(taskListener));
+            launcher,  getContext().get(EnvVars.class));
       } catch (Exception e) {
         taskListener.fatalError(e.getMessage());
         throw new IOException(e.getCause());

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -16,6 +16,7 @@ import com.browserstack.automate.ci.jenkins.BrowserStackCredentials;
 import com.browserstack.automate.ci.jenkins.local.BrowserStackLocalUtils;
 import com.browserstack.automate.ci.jenkins.local.JenkinsBrowserStackLocal;
 import com.browserstack.automate.ci.jenkins.local.LocalConfig;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -62,7 +63,7 @@ public class BrowserStackPipelineStepExecution extends SynchronousNonBlockingSte
     if (accessKey != null && this.localConfig != null) {
       try {
         startBrowserStackLocal(run.getFullDisplayName(), taskListener.getLogger(), accessKey,
-            launcher);
+            launcher, run.getEnvironment(taskListener));
       } catch (Exception e) {
         taskListener.fatalError(e.getMessage());
         throw new IOException(e.getCause());
@@ -83,8 +84,8 @@ public class BrowserStackPipelineStepExecution extends SynchronousNonBlockingSte
   }
 
   public void startBrowserStackLocal(String buildTag, PrintStream logger, String accessKey,
-      Launcher launcher) throws Exception {
-    browserStackLocal = new JenkinsBrowserStackLocal(accessKey, localConfig, buildTag);
+      Launcher launcher, EnvVars envVars) throws Exception {
+    browserStackLocal = new JenkinsBrowserStackLocal(accessKey, localConfig, buildTag, envVars, logger);
     log(logger, "Local: Starting BrowserStack Local...");
     browserStackLocal.start(launcher);
     log(logger, "Local: Started");

--- a/src/test/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocalTest.java
+++ b/src/test/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocalTest.java
@@ -65,5 +65,27 @@ public class JenkinsBrowserStackLocalTest {
        Assert.assertTrue("Local arguments should contain $proxy_user ", ArrayUtils.contains(arguments, PROXY_USER));
        Assert.assertTrue("Local arguments should contain $proxy_password ", ArrayUtils.contains(arguments, PROXY_PASSWORD));
     }
+    
+    @Test
+    public void testLocalIdentifierWithEnvLocalOptions() {
+      LocalConfig localConfig = new LocalConfig();
+      localConfig.setLocalOptions("--local-identifier "+ LOCAL_IDENTIFIER +" --proxy-host $proxy_host --proxy-port $proxy_port --proxy-user $proxy_user --proxy-password $proxy_password");
+      String buildTag = "tag";
+      EnvVars envVars = new EnvVars();
+      envVars.put("proxy_host", PROXY_HOST);
+      envVars.put("proxy_port", PROXY_PORT);
+      envVars.put("proxy_user", PROXY_USER);
+      envVars.put("proxy_password", PROXY_PASSWORD);
+      JenkinsBrowserStackLocal jenkinsBSLocal = new JenkinsBrowserStackLocal(ACCESS_KEY, localConfig, buildTag, envVars, System.out);
+      String[] arguments = jenkinsBSLocal.getArguments();
+      String localIdentifier = jenkinsBSLocal.getLocalIdentifier();
+     
+      Assert.assertTrue("Local arguments should contain $proxy_host ", ArrayUtils.contains(arguments, PROXY_HOST));
+      Assert.assertTrue("Local arguments should contain $proxy_port ", ArrayUtils.contains(arguments, PROXY_PORT));
+      Assert.assertTrue("Local arguments should contain $proxy_user ", ArrayUtils.contains(arguments, PROXY_USER));
+      Assert.assertTrue("Local arguments should contain $proxy_password ", ArrayUtils.contains(arguments, PROXY_PASSWORD));
+      Assert.assertEquals("Local identifier should be overriden when passed through localOption", LOCAL_IDENTIFIER, localIdentifier);
+      
+    }
 
 }

--- a/src/test/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocalTest.java
+++ b/src/test/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocalTest.java
@@ -4,21 +4,66 @@ import org.junit.runner.RunWith;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.commons.lang.ArrayUtils;
+import hudson.EnvVars;
+import org.junit.Assert;
+import org.junit.Test;
 
 
 @RunWith(JUnitQuickcheck.class)
 public class JenkinsBrowserStackLocalTest {
 
     public final String ACCESS_KEY = "dummy";
+    private final String PROXY_HOST = "test.proxy.host";
+    private final String PROXY_PORT = "1234";
+    private final String PROXY_USER = "testUser";
+    private final String PROXY_PASSWORD = "testPassword";
+    private final String LOCAL_IDENTIFIER = "dummyIdentifier";
 
     @Property
     public void testLocalIdentifierGeneration(String buildTag) {
         LocalConfig localConfig = new LocalConfig();
-        JenkinsBrowserStackLocal jenkinsBSLocal = new JenkinsBrowserStackLocal(ACCESS_KEY, localConfig, buildTag);
-
+        JenkinsBrowserStackLocal jenkinsBSLocal = new JenkinsBrowserStackLocal(ACCESS_KEY, localConfig, buildTag, null, null);
         String localIdentifier = jenkinsBSLocal.getLocalIdentifier();
 
         assertThat(localIdentifier).matches("^[a-zA-Z0-9_\\-\\.]+$");
+    }
+    
+    @Test
+    public void testLocalIdentifierOverride() {
+        LocalConfig localConfig = new LocalConfig();
+        localConfig.setLocalOptions("--local-identifier " + LOCAL_IDENTIFIER);
+        JenkinsBrowserStackLocal jenkinsBSLocal = new JenkinsBrowserStackLocal(ACCESS_KEY, localConfig, "buildTag", null, null);
+        String localIdentifier = jenkinsBSLocal.getLocalIdentifier();
+        Assert.assertEquals("Local identifier should be overriden when passed through localOption", LOCAL_IDENTIFIER, localIdentifier);
+    }
+  
+    @Test
+    public void testLocalIdentifierNotOverride() {
+        LocalConfig localConfig = new LocalConfig();
+        localConfig.setLocalOptions("--local-identifier ");
+        JenkinsBrowserStackLocal jenkinsBSLocal = new JenkinsBrowserStackLocal(ACCESS_KEY, localConfig, "buildTag", null, null);
+        String localIdentifier = jenkinsBSLocal.getLocalIdentifier();
+        Assert.assertTrue("Local identifier should not overriden when blank", !localIdentifier.equals(LOCAL_IDENTIFIER));
+    }
+  
+    @Test
+    public void testEnvLocalOptions(){
+       LocalConfig localConfig = new LocalConfig();
+       localConfig.setLocalOptions("--force-proxy --proxy-host $proxy_host --proxy-port $proxy_port --proxy-user $proxy_user --proxy-password $proxy_password");
+       String buildTag = "tag";
+       EnvVars envVars = new EnvVars();
+       envVars.put("proxy_host", PROXY_HOST);
+       envVars.put("proxy_port", PROXY_PORT);
+       envVars.put("proxy_user", PROXY_USER);
+       envVars.put("proxy_password", PROXY_PASSWORD);
+       JenkinsBrowserStackLocal jenkinsBSLocal = new JenkinsBrowserStackLocal(ACCESS_KEY, localConfig, buildTag, envVars, System.out);
+       String[] arguments = jenkinsBSLocal.getArguments();
+      
+       Assert.assertTrue("Local arguments should contain $proxy_host ", ArrayUtils.contains(arguments, PROXY_HOST));
+       Assert.assertTrue("Local arguments should contain $proxy_port ", ArrayUtils.contains(arguments, PROXY_PORT));
+       Assert.assertTrue("Local arguments should contain $proxy_user ", ArrayUtils.contains(arguments, PROXY_USER));
+       Assert.assertTrue("Local arguments should contain $proxy_password ", ArrayUtils.contains(arguments, PROXY_PASSWORD));
     }
 
 }


### PR DESCRIPTION
*  feature: Environment variables in local options
    * This will allow users to interpolate env variables in local options without hardcoding it in local options textbox. Example: when passing `--proxy-user $proxy_user` to local options, plugin will look for `$proxy_user` in build environment 
    * Applicable for all local options
    * Compatible with Jenkins Credential binding plugin

*  fix: `--local-identifier` not getting overridden when passed in local options
    * added `--local-identifier` in filter along with `-localIdentifier`

* fix: arguments after `-localIdentifier` getting ignored 
