### PR TITLE
jenkins-pipleline-step-execution

### DIFF
--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
@@ -42,9 +42,8 @@ public class AppUploadStepExecution extends SynchronousNonBlockingStepExecution<
             return null;
         }
 
-        EnvVars overrides = run.getEnvironment(taskListener);
-        overrides.put(BrowserStackEnvVars.BROWSERSTACK_APP_ID, appId);
-        HashMap<String, String> overridesMap = new HashMap<>(overrides);
+        HashMap<String, String> overridesMap = new HashMap<String, String>();
+        overridesMap.put(BrowserStackEnvVars.BROWSERSTACK_APP_ID, appId);
 
         body = getContext().newBodyInvoker()
                 .withContext(EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class),

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -87,7 +87,9 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
                 new BrowserStackBuildWrapperOperations(credentials, false, taskListener.getLogger(),
                         localConfig, browserStackLocal);
 
+        EnvVars overrides = run.getEnvironment(taskListener);
         HashMap<String, String> overridesMap = new HashMap<String, String>();
+        overridesMap.put(Constants.JENKINS_BUILD_TAG, overrides.get(Constants.JENKINS_BUILD_TAG));
         buildWrapperOperations.buildEnvVars(overridesMap);
 
         body = getContext()
@@ -95,7 +97,6 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
                         .merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(overridesMap)))
                 .withCallback(new Callback(browserStackLocal)).start();
 
-        EnvVars overrides = run.getEnvironment(taskListener);
         tracker.pluginInitialized(overrides.get(Constants.JENKINS_BUILD_TAG),
                 (this.localConfig != null), true);
         return false;

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -16,7 +16,7 @@ import org.jenkinsci.plugins.workflow.steps.BodyExecution;
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
-import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import static com.browserstack.automate.ci.common.logger.PluginLogger.log;
 import static com.browserstack.automate.ci.common.logger.PluginLogger.logError;
 
-public class BrowserStackPipelineStepExecution extends SynchronousNonBlockingStepExecution<Void> {
+public class BrowserStackPipelineStepExecution extends StepExecution {
     private static final long serialVersionUID = -8810137779949881645L;
     private String credentialsId;
     private StepContext context;
@@ -42,7 +42,7 @@ public class BrowserStackPipelineStepExecution extends SynchronousNonBlockingSte
     }
 
     @Override
-    protected Void run() throws Exception {
+    public boolean start() throws Exception {
         Run run = context.get(Run.class);
         TaskListener taskListener = context.get(TaskListener.class);
         Launcher launcher = context.get(Launcher.class);
@@ -55,7 +55,7 @@ public class BrowserStackPipelineStepExecution extends SynchronousNonBlockingSte
         if (credentials == null) {
             logError(logger, "Credentials id is invalid. Aborting!!!");
             tracker.sendError("No Credentials Available", true, "PipelineExecution");
-            return null;
+            return false;
         }
 
         if (credentials.hasUsername() && credentials.hasAccesskey()) {
@@ -97,7 +97,7 @@ public class BrowserStackPipelineStepExecution extends SynchronousNonBlockingSte
 
         tracker.pluginInitialized(overrides.get(Constants.JENKINS_BUILD_TAG),
                 (this.localConfig != null), true);
-        return null;
+        return false;
     }
 
     public void startBrowserStackLocal(String buildTag, PrintStream logger, String accessKey,

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -55,7 +55,8 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
         if (credentials == null) {
             logError(logger, "Credentials id is invalid. Aborting!!!");
             tracker.sendError("No Credentials Available", true, "PipelineExecution");
-            return false;
+            context.onFailure(new Exception("No Credentials Available"));
+            return true;
         }
 
         if (credentials.hasUsername() && credentials.hasAccesskey()) {

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -87,8 +87,7 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
                 new BrowserStackBuildWrapperOperations(credentials, false, taskListener.getLogger(),
                         localConfig, browserStackLocal);
 
-        EnvVars overrides = run.getEnvironment(taskListener);
-        HashMap<String, String> overridesMap = new HashMap<String, String>(overrides);
+        HashMap<String, String> overridesMap = new HashMap<String, String>();
         buildWrapperOperations.buildEnvVars(overridesMap);
 
         body = getContext()
@@ -96,6 +95,7 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
                         .merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(overridesMap)))
                 .withCallback(new Callback(browserStackLocal)).start();
 
+        EnvVars overrides = run.getEnvironment(taskListener);
         tracker.pluginInitialized(overrides.get(Constants.JENKINS_BUILD_TAG),
                 (this.localConfig != null), true);
         return false;


### PR DESCRIPTION
Using general StepExecution class instead of SynchronousNonBlockingStepExecution to capture exceptions inside body call
Also, adding fix for overriding global to local envs issue