### PR TITLE
Proxy from multiple sources with priority. Custom Local Identifier fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ hs_err_pid*
 .project
 .settings/
 /bin/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <a href="https://browserstack.com"><img alt="BrowserStack Logo" src="https://d98b8t1nnulk5.cloudfront.net/production/images/layout/logo-invoice.svg"></a>
+</p>
+
 # Overview
 [BrowserStack](https://browserstack.com) gives instant access to 2000+ real mobile devices and browsers that enables developers to test their websites and mobile applications without requiring to install or maintain an internal lab of virtual machines, devices, or emulators.
 

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <dependency>
       <groupId>com.browserstack</groupId>
       <artifactId>browserstack-local-java</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.6</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.1.10-SNAPSHOT</version>
+  <version>1.2.0</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>com.browserstack</groupId>
       <artifactId>automate-client-java</artifactId>
-      <version>0.6</version>
+      <version>0.7</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/browserstack/automate/ci/common/clienthandler/ClientHandler.java
+++ b/src/main/java/com/browserstack/automate/ci/common/clienthandler/ClientHandler.java
@@ -1,0 +1,41 @@
+package com.browserstack.automate.ci.common.clienthandler;
+
+import com.browserstack.appautomate.AppAutomateClient;
+import com.browserstack.automate.AutomateClient;
+import com.browserstack.automate.ci.common.enums.ProjectType;
+import com.browserstack.automate.ci.common.proxysettings.JenkinsProxySettings;
+import com.browserstack.client.BrowserStackClient;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.PrintStream;
+
+public class ClientHandler {
+
+    public static BrowserStackClient getBrowserStackClient(@Nonnull final ProjectType project, @Nonnull final String username,
+                                                           @Nonnull final String accessKey, @Nullable final String customProxy,
+                                                           @Nullable final PrintStream logger) {
+        BrowserStackClient client = decideAndGetClient(project, username, accessKey);
+
+        JenkinsProxySettings proxy;
+        if (customProxy != null) {
+            proxy = new JenkinsProxySettings(customProxy, logger);
+        } else {
+            proxy = new JenkinsProxySettings(logger);
+        }
+
+        if (proxy.hasProxy()) {
+            client.setProxy(proxy.getHost(), proxy.getPort(), proxy.getUsername(), proxy.getPassword());
+        }
+
+        return client;
+    }
+
+    private static BrowserStackClient decideAndGetClient(@Nonnull final ProjectType project, @Nonnull final String username, @Nonnull final String accessKey) {
+        if (project == ProjectType.APP_AUTOMATE) {
+            return new AppAutomateClient(username, accessKey);
+        }
+
+        return new AutomateClient(username, accessKey);
+    }
+}

--- a/src/main/java/com/browserstack/automate/ci/common/clienthandler/ClientHandler.java
+++ b/src/main/java/com/browserstack/automate/ci/common/clienthandler/ClientHandler.java
@@ -12,6 +12,16 @@ import java.io.PrintStream;
 
 public class ClientHandler {
 
+    /**
+     * Returns BrowserStackClient based on Project, i.e Automate or App Automate.
+     * Also decides and sets the proxy for the client
+     * @param project ProjectType
+     * @param username Username of BrowserStack
+     * @param accessKey Access Key of BrowserStack
+     * @param customProxy Custom Proxy String
+     * @param logger Logger
+     * @return BrowserStackClient
+     */
     public static BrowserStackClient getBrowserStackClient(@Nonnull final ProjectType project, @Nonnull final String username,
                                                            @Nonnull final String accessKey, @Nullable final String customProxy,
                                                            @Nullable final PrintStream logger) {
@@ -31,6 +41,13 @@ public class ClientHandler {
         return client;
     }
 
+    /**
+     * Initializes BrowserStack client based on project type
+     * @param project ProjectType
+     * @param username Username of BrowserStack
+     * @param accessKey Access Key of BrowserStack
+     * @return BrowserStackClient
+     */
     private static BrowserStackClient decideAndGetClient(@Nonnull final ProjectType project, @Nonnull final String username, @Nonnull final String accessKey) {
         if (project == ProjectType.APP_AUTOMATE) {
             return new AppAutomateClient(username, accessKey);

--- a/src/main/java/com/browserstack/automate/ci/common/proxysettings/JenkinsProxySettings.java
+++ b/src/main/java/com/browserstack/automate/ci/common/proxysettings/JenkinsProxySettings.java
@@ -152,9 +152,9 @@ public class JenkinsProxySettings {
         if (this.finalProxyHost != null && this.finalProxyPort != 0) {
             this.hasProxy = true;
 
-            String proxyDataToLog = "\nHost: " + this.getHost() + "\nPort: " + this.getPort();
+            String proxyDataToLog = "Host: " + this.getHost() + ", Port: " + this.getPort();
             if (this.hasAuth()) {
-                proxyDataToLog += "\nUsername: " + this.getUsername() + "\nPassword: " + Tools.maskString(this.getPassword());
+                proxyDataToLog += ", Username: " + this.getUsername() + ", Password: " + Tools.maskString(this.getPassword());
             }
 
             if (logger != null) log(logger, "Proxy Selected for BrowserStack Plugin: " + proxyDataToLog);
@@ -178,6 +178,10 @@ public class JenkinsProxySettings {
         return systemHttpsProxyEnv == null ? systemHttpProxyEnv : systemHttpsProxyEnv;
     }
 
+    /**
+     * Returns Jenkins proxy configuration in Proxy object
+     * @return Proxy object
+     */
     public Proxy getJenkinsProxy() {
         if (this.hasProxy()) {
             return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.finalProxyHost, this.finalProxyPort));

--- a/src/main/java/com/browserstack/automate/ci/common/proxysettings/JenkinsProxySettings.java
+++ b/src/main/java/com/browserstack/automate/ci/common/proxysettings/JenkinsProxySettings.java
@@ -1,77 +1,218 @@
 package com.browserstack.automate.ci.common.proxysettings;
 
+import com.browserstack.automate.ci.common.Tools;
 import hudson.ProxyConfiguration;
+import hudson.Util;
 import jenkins.model.Jenkins;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.URL;
+
+import static com.browserstack.automate.ci.common.logger.PluginLogger.log;
+import static com.browserstack.automate.ci.common.logger.PluginLogger.logError;
 
 public class JenkinsProxySettings {
 
     private static final ProxyConfiguration jenkinsProxy = Jenkins.getInstanceOrNull() != null ? Jenkins.getInstanceOrNull().proxy : null;
-    private static final String protocol = "https";
-    private static final String systemProxyHost = System.getProperty(protocol + ".proxyHost");
-    private static final int systemProxyPort = Integer.parseInt(System.getProperty(protocol + ".proxyPort", "0"));
-    private static final String systemProxyUser = System.getProperty(protocol + ".proxyUser");
-    private static final String systemProxyPassword = System.getProperty(protocol + ".proxyPassword");
 
-    public static Proxy getJenkinsProxy() {
-        if (hasSystemProxy()) {
-            return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(systemProxyHost, systemProxyPort));
+    private static final String jarProxyHost = System.getProperty("https.proxyHost");
+    private static final int jarProxyPort = Integer.parseInt(System.getProperty("https.proxyPort", "443"));
+    private static final String jarProxyUser = System.getProperty("https.proxyUser");
+    private static final String jarProxyPassword = System.getProperty("https.proxyPassword");
+
+    private static final String systemHttpProxyEnv = System.getenv("http_proxy");
+    private static final String systemHttpsProxyEnv = System.getenv("https_proxy");
+
+    private String finalProxyHost;
+    private int finalProxyPort;
+    private String finalProxyUsername;
+    private String finalProxyPassword;
+
+    private boolean hasProxy;
+
+    private transient PrintStream logger;
+
+    /**
+     * Constructor for JenkinsProxySettings with Priority for Custom Proxy
+     *
+     * @param customProxy Custom Proxy String
+     * @param logger      Logger
+     */
+    public JenkinsProxySettings(@Nonnull final String customProxy, @Nullable PrintStream logger) {
+        this.logger = logger;
+        decideJenkinsProxy(customProxy);
+    }
+
+    /**
+     * Constructor for JenkinsProxySettings
+     *
+     * @param logger Logger
+     */
+    public JenkinsProxySettings(@Nullable PrintStream logger) {
+        this.logger = logger;
+        decideJenkinsProxy(null);
+    }
+
+    /**
+     * Verifies the format of the Proxy String
+     *
+     * @param proxyString String
+     * @param proxyType   Type/Source of Proxy
+     * @return
+     */
+    private URL verifyAndGetProxyURL(final String proxyString, final String proxyType) {
+        try {
+            final URL proxyUrl = new URL(proxyString);
+            if (proxyUrl.getHost() != null && proxyUrl.getHost().length() == 0)
+                throw new Error("Empty host in proxy");
+
+            String userInfo = proxyUrl.getUserInfo();
+            if (userInfo != null) {
+                if (userInfo.split(":").length != 2) {
+                    throw new Error("Invalid authentication params in proxy");
+                }
+            }
+
+            return proxyUrl;
+        } catch (Exception e) {
+            // TODO: Change to logDebug
+            if (logger != null)
+                logError(logger, String.format("Invalid Proxy String: %s, Proxy Type: %s. Error: %s", proxyString, proxyType, e.toString()));
+            return null;
+        }
+    }
+
+    /**
+     * Decides Proxy for the Plugin. Priority:
+     * 0. Custom Proxy passed as input
+     * 1. `https_proxy` Environment Variable
+     * 2. `http_proxy` Environment Variable
+     * 3. Jenkins Proxy Configuration
+     * 4. JAR Proxy arguments, i.e. `https.proxyHost` etc.
+     *
+     * @param customProxyString Custom Proxy String
+     */
+    private void decideJenkinsProxy(final String customProxyString) {
+        URL proxyUrl = null;
+
+        // Verifies the custom proxy string
+        if (customProxyString != null) {
+            proxyUrl = verifyAndGetProxyURL(customProxyString, "ENV_VAR");
         }
 
-        if (jenkinsProxy == null) return null;
-        final String proxyHost = jenkinsProxy.name;
-        final int proxyPort = jenkinsProxy.port;
-        return (proxyHost != null && proxyPort != 0) ? new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort)) : null;
-    }
-
-    public static String getHost() {
-        if (hasSystemProxy()) {
-            return systemProxyHost;
+        // Looks for System level `https_proxy`. If not, looks for `http_proxy`
+        if (proxyUrl == null && getSystemProxyString() != null) {
+            proxyUrl = verifyAndGetProxyURL(getSystemProxyString(), "SYSTEM_ENV_VAR");
         }
 
-        if (jenkinsProxy == null) return null;
-        return jenkinsProxy.name;
-    }
+        // Looks for Jenkins Proxy
+        if (proxyUrl == null && jenkinsProxy != null) {
+            this.finalProxyHost = jenkinsProxy.name;
+            this.finalProxyPort = jenkinsProxy.port;
 
-    public static int getPort() {
-        if (hasSystemProxy()) {
-            return systemProxyPort;
+            if (Util.fixEmpty(jenkinsProxy.getUserName()) != null && Util.fixEmpty(jenkinsProxy.getPassword()) != null) {
+                this.finalProxyUsername = jenkinsProxy.getUserName();
+                this.finalProxyPassword = jenkinsProxy.getPassword();
+            }
         }
 
-        if (jenkinsProxy == null) return 0;
-        return jenkinsProxy.port;
-    }
+        // Looks for JAR Proxy Arguments
+        if (proxyUrl == null && this.finalProxyHost == null && jarProxyHost != null) {
+            this.finalProxyHost = jarProxyHost;
+            this.finalProxyPort = jarProxyPort;
 
-    public static String getUsername() {
-        if (hasSystemProxy() && systemProxyUser != null && systemProxyPassword != null) {
-            return systemProxyUser;
+            if (Util.fixEmpty(jarProxyUser) != null && Util.fixEmpty(jarProxyPassword) != null) {
+                this.finalProxyUsername = jarProxyUser;
+                this.finalProxyPassword = jarProxyPassword;
+            }
+
+            if (this.finalProxyUsername == null)
+                System.out.println("Username is null in case of JAR proxy...");
         }
 
-        if (jenkinsProxy == null) return null;
-        return jenkinsProxy.getUserName();
-    }
+        // Utilises the proxyUrl set by Env Vars if Jenkins & Jar Proxy are absent
+        if (proxyUrl != null) {
+            this.finalProxyHost = proxyUrl.getHost();
+            this.finalProxyPort = proxyUrl.getPort() == -1 ? proxyUrl.getDefaultPort() : proxyUrl.getPort();
 
-    public static String getPassword() {
-        if (hasSystemProxy() && systemProxyUser != null && systemProxyPassword != null) {
-            return systemProxyPassword;
+            final String userInfo = proxyUrl.getUserInfo();
+
+            if (userInfo != null) {
+                String[] userInfoArray = userInfo.split(":");
+                this.finalProxyUsername = userInfoArray[0];
+                this.finalProxyPassword = userInfoArray[1];
+            }
         }
 
-        if (jenkinsProxy == null) return null;
-        return jenkinsProxy.getPassword();
+        // Logging and final boolean set
+        if (this.finalProxyHost != null && this.finalProxyPort != 0) {
+            this.hasProxy = true;
+
+            String proxyDataToLog = "\nHost: " + this.getHost() + "\nPort: " + this.getPort();
+            if (this.hasAuth()) {
+                proxyDataToLog += "\nUsername: " + this.getUsername() + "\nPassword: " + Tools.maskString(this.getPassword());
+            }
+
+            if (logger != null) log(logger, "Proxy Selected for BrowserStack Plugin: " + proxyDataToLog);
+        } else {
+            this.hasProxy = false;
+
+            if (logger != null) log(logger, "No Proxy Selected for BrowserStack Plugin");
+        }
     }
 
-    public static ProxyConfiguration getProxyConfig() {
-        return jenkinsProxy;
+
+    /**
+     * Returns the proxy string from System level env vars. Priority:
+     * 1. `https_proxy`
+     * 2. `http_proxy`
+     * If no value exists, returns null
+     *
+     * @return String/null
+     */
+    private String getSystemProxyString() {
+        return systemHttpsProxyEnv == null ? systemHttpProxyEnv : systemHttpsProxyEnv;
     }
 
-    public static boolean hasProxy() {
-        return getHost() != null && getPort() != 0;
+    public Proxy getJenkinsProxy() {
+        if (this.hasProxy()) {
+            return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(this.finalProxyHost, this.finalProxyPort));
+        }
+
+        return Proxy.NO_PROXY;
     }
 
-    public static boolean hasSystemProxy() {
-        return systemProxyHost != null && systemProxyPort != 0;
+    public String getHost() {
+        return this.finalProxyHost;
     }
 
+    public int getPort() {
+        return this.finalProxyPort;
+    }
+
+    public String getUsername() {
+        if (this.finalProxyUsername != null && this.finalProxyUsername.length() != 0)
+            return this.finalProxyUsername;
+
+        return null;
+    }
+
+    public String getPassword() {
+        if (this.finalProxyPassword != null && this.finalProxyPassword.length() != 0)
+            return this.finalProxyPassword;
+
+        return null;
+    }
+
+    public boolean hasAuth() {
+        return ((this.getUsername() != null) && (this.getPassword() != null));
+    }
+
+    public boolean hasProxy() {
+        return this.hasProxy;
+    }
 }

--- a/src/main/java/com/browserstack/automate/ci/common/proxysettings/JenkinsProxySettings.java
+++ b/src/main/java/com/browserstack/automate/ci/common/proxysettings/JenkinsProxySettings.java
@@ -13,7 +13,7 @@ import java.net.Proxy;
 import java.net.URL;
 
 import static com.browserstack.automate.ci.common.logger.PluginLogger.log;
-import static com.browserstack.automate.ci.common.logger.PluginLogger.logError;
+import static com.browserstack.automate.ci.common.logger.PluginLogger.logDebug;
 
 public class JenkinsProxySettings {
 
@@ -79,9 +79,8 @@ public class JenkinsProxySettings {
 
             return proxyUrl;
         } catch (Exception e) {
-            // TODO: Change to logDebug
             if (logger != null)
-                logError(logger, String.format("Invalid Proxy String: %s, Proxy Type: %s. Error: %s", proxyString, proxyType, e.toString()));
+                logDebug(logger, String.format("Invalid Proxy String: %s, Proxy Type: %s. Error: %s", proxyString, proxyType, e.toString()));
             return null;
         }
     }
@@ -129,9 +128,6 @@ public class JenkinsProxySettings {
                 this.finalProxyUsername = jarProxyUser;
                 this.finalProxyPassword = jarProxyPassword;
             }
-
-            if (this.finalProxyUsername == null)
-                System.out.println("Username is null in case of JAR proxy...");
         }
 
         // Utilises the proxyUrl set by Env Vars if Jenkins & Jar Proxy are absent
@@ -180,6 +176,7 @@ public class JenkinsProxySettings {
 
     /**
      * Returns Jenkins proxy configuration in Proxy object
+     *
      * @return Proxy object
      */
     public Proxy getJenkinsProxy() {

--- a/src/main/java/com/browserstack/automate/ci/common/tracking/PluginsTracker.java
+++ b/src/main/java/com/browserstack/automate/ci/common/tracking/PluginsTracker.java
@@ -25,8 +25,8 @@ import java.util.Optional;
 public class PluginsTracker {
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
     private static final String URL = "https://api.browserstack.com/ci_plugins/track";
-    private transient OkHttpClient client;
     private final String trackingId;
+    private transient OkHttpClient client;
     private String username;
     private String accessKey;
     private String customProxy;
@@ -77,16 +77,13 @@ public class PluginsTracker {
 
         JenkinsProxySettings jenkinsProxy;
         if (customProxy != null) {
-            System.out.println("Custom Proxy In Plugins Tracker: " + customProxy);
             jenkinsProxy = new JenkinsProxySettings(customProxy, null);
         } else {
-            System.out.println("Without Custom Proxy In Plugins Tracker");
             jenkinsProxy = new JenkinsProxySettings(null);
         }
 
         final Proxy proxy = jenkinsProxy.getJenkinsProxy();
         if (proxy != Proxy.NO_PROXY) {
-            System.out.println("Selected some proxy for plugins tracker. " + proxy.toString() + ". And auth: " + jenkinsProxy.hasAuth());
             if (jenkinsProxy.hasAuth()) {
                 final String username = jenkinsProxy.getUsername();
                 final String password = jenkinsProxy.getPassword();

--- a/src/main/java/com/browserstack/automate/ci/common/tracking/PluginsTracker.java
+++ b/src/main/java/com/browserstack/automate/ci/common/tracking/PluginsTracker.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 public class PluginsTracker {
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
     private static final String URL = "https://api.browserstack.com/ci_plugins/track";
-    private static OkHttpClient client;
+    private transient OkHttpClient client;
     private final String trackingId;
     private String username;
     private String accessKey;
@@ -51,7 +51,7 @@ public class PluginsTracker {
         initializeClient();
     }
 
-    private static void asyncPostRequestSilent(final String url, final String json) {
+    private void asyncPostRequestSilent(final String url, final String json) {
         RequestBody body = RequestBody.create(JSON, json);
         Request request = new Request.Builder()
                 .url(url)
@@ -86,7 +86,7 @@ public class PluginsTracker {
 
         final Proxy proxy = jenkinsProxy.getJenkinsProxy();
         if (proxy != Proxy.NO_PROXY) {
-            System.out.println("Selected some proxy for plugins tracker. " + proxy.toString());
+            System.out.println("Selected some proxy for plugins tracker. " + proxy.toString() + ". And auth: " + jenkinsProxy.hasAuth());
             if (jenkinsProxy.hasAuth()) {
                 final String username = jenkinsProxy.getUsername();
                 final String password = jenkinsProxy.getPassword();
@@ -99,12 +99,12 @@ public class PluginsTracker {
                                 .build();
                     }
                 };
-                this.client = new OkHttpClient.Builder().proxy(proxy).proxyAuthenticator(proxyAuthenticator).build();
+                client = new OkHttpClient.Builder().proxy(proxy).proxyAuthenticator(proxyAuthenticator).build();
             } else {
-                this.client = new OkHttpClient.Builder().proxy(proxy).build();
+                client = new OkHttpClient.Builder().proxy(proxy).build();
             }
         } else {
-            this.client = new OkHttpClient.Builder().build();
+            client = new OkHttpClient.Builder().build();
         }
     }
 

--- a/src/main/java/com/browserstack/automate/ci/common/tracking/PluginsTracker.java
+++ b/src/main/java/com/browserstack/automate/ci/common/tracking/PluginsTracker.java
@@ -16,6 +16,7 @@ import okhttp3.Response;
 import okhttp3.Route;
 import org.json.JSONObject;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.Proxy;
 import java.time.Instant;
@@ -28,17 +29,24 @@ public class PluginsTracker {
     private final String trackingId;
     private String username;
     private String accessKey;
+    private String customProxy;
 
-    public PluginsTracker(final String username, final String accessKey) {
+    public PluginsTracker(final String username, final String accessKey, @Nullable final String customProxy) {
         this.username = username;
         this.accessKey = accessKey;
+        this.customProxy = customProxy;
         this.trackingId = Tools.getUniqueString(true, true);
         initializeClient();
     }
 
     public PluginsTracker() {
+        this(null);
+    }
+
+    public PluginsTracker(@Nullable final String customProxy) {
         this.username = null;
         this.accessKey = null;
+        this.customProxy = customProxy;
         this.trackingId = Tools.getUniqueString(true, true);
         initializeClient();
     }
@@ -67,11 +75,21 @@ public class PluginsTracker {
 
     private void initializeClient() {
 
-        final Proxy proxy = JenkinsProxySettings.getJenkinsProxy() != null ? JenkinsProxySettings.getJenkinsProxy() : Proxy.NO_PROXY;
+        JenkinsProxySettings jenkinsProxy;
+        if (customProxy != null) {
+            System.out.println("Custom Proxy In Plugins Tracker: " + customProxy);
+            jenkinsProxy = new JenkinsProxySettings(customProxy, null);
+        } else {
+            System.out.println("Without Custom Proxy In Plugins Tracker");
+            jenkinsProxy = new JenkinsProxySettings(null);
+        }
+
+        final Proxy proxy = jenkinsProxy.getJenkinsProxy();
         if (proxy != Proxy.NO_PROXY) {
-            final String username = JenkinsProxySettings.getUsername();
-            final String password = JenkinsProxySettings.getPassword();
-            if (username != null && password != null) {
+            System.out.println("Selected some proxy for plugins tracker. " + proxy.toString());
+            if (jenkinsProxy.hasAuth()) {
+                final String username = jenkinsProxy.getUsername();
+                final String password = jenkinsProxy.getPassword();
                 Authenticator proxyAuthenticator = new Authenticator() {
                     @Override
                     public Request authenticate(Route route, Response response) throws IOException {

--- a/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploader.java
+++ b/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploader.java
@@ -36,8 +36,6 @@ public class AppUploader {
         }
 
         if (proxy.hasProxy()) {
-            System.out.println("App upload setting proxy for app automate client...");
-            System.out.println(proxy.getHost() + ":" + proxy.getPort() + "," + proxy.getUsername() + ":" + proxy.getPassword());
             appAutomateClient.setProxy(proxy.getHost(), proxy.getPort(), proxy.getUsername(), proxy.getPassword());
         }
         return appAutomateClient.uploadApp(this.appPath).getAppUrl();

--- a/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploader.java
+++ b/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploader.java
@@ -1,6 +1,7 @@
 package com.browserstack.automate.ci.common.uploader;
 
 import java.io.FileNotFoundException;
+import java.io.PrintStream;
 
 import com.browserstack.appautomate.AppAutomateClient;
 import com.browserstack.automate.ci.common.proxysettings.JenkinsProxySettings;
@@ -12,18 +13,30 @@ public class AppUploader {
 
     String appPath;
     BrowserStackCredentials credentials;
+    private final PrintStream logger;
+    private final String customProxy;
 
-    public AppUploader(String appPath, BrowserStackCredentials credentials) {
+    public AppUploader(String appPath, BrowserStackCredentials credentials, final String customProxy, final PrintStream logger) {
         this.appPath = appPath;
         this.credentials = credentials;
+        this.logger = logger;
+        this.customProxy = customProxy;
     }
 
     public String uploadFile()
             throws AppAutomateException, FileNotFoundException, InvalidFileExtensionException {
         AppAutomateClient appAutomateClient =
                 new AppAutomateClient(credentials.getUsername(), credentials.getDecryptedAccesskey());
-        if (JenkinsProxySettings.hasProxy()) {
-            appAutomateClient.setProxy(JenkinsProxySettings.getHost(), JenkinsProxySettings.getPort(), JenkinsProxySettings.getUsername(), JenkinsProxySettings.getPassword());
+
+        JenkinsProxySettings proxy;
+        if (customProxy != null) {
+            proxy = new JenkinsProxySettings(customProxy, logger);
+        } else {
+            proxy = new JenkinsProxySettings(logger);
+        }
+
+        if (proxy.hasProxy()) {
+            appAutomateClient.setProxy(proxy.getHost(), proxy.getPort(), proxy.getUsername(), proxy.getPassword());
         }
         return appAutomateClient.uploadApp(this.appPath).getAppUrl();
     }

--- a/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploader.java
+++ b/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploader.java
@@ -13,7 +13,7 @@ public class AppUploader {
 
     String appPath;
     BrowserStackCredentials credentials;
-    private final PrintStream logger;
+    private final transient PrintStream logger;
     private final String customProxy;
 
     public AppUploader(String appPath, BrowserStackCredentials credentials, final String customProxy, final PrintStream logger) {
@@ -36,6 +36,8 @@ public class AppUploader {
         }
 
         if (proxy.hasProxy()) {
+            System.out.println("App upload setting proxy for app automate client...");
+            System.out.println(proxy.getHost() + ":" + proxy.getPort() + "," + proxy.getUsername() + ":" + proxy.getPassword());
             appAutomateClient.setProxy(proxy.getHost(), proxy.getPort(), proxy.getUsername(), proxy.getPassword());
         }
         return appAutomateClient.uploadApp(this.appPath).getAppUrl();

--- a/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploaderHelper.java
+++ b/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploaderHelper.java
@@ -29,7 +29,7 @@ public class AppUploaderHelper {
     return FormValidation.ok();
   }
 
-  public static String uploadApp(Actionable build, PrintStream logger, String appPath) {
+  public static String uploadApp(Actionable build, PrintStream logger, String appPath, final String customProxy) {
     PluginLogger.log(logger, "Starting upload process.");
 
     BrowserStackBuildAction browserStackBuildAction =
@@ -45,7 +45,7 @@ public class AppUploaderHelper {
       return null;
     }
 
-    AppUploader appUploader = new AppUploader(appPath, credentials);
+    AppUploader appUploader = new AppUploader(appPath, credentials, customProxy, logger);
     String appId = "";
     try {
       PluginLogger.log(logger, "Uploading app " + appPath + " to Browserstack.");

--- a/src/main/java/com/browserstack/automate/ci/jenkins/AppUploaderBuilder.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/AppUploaderBuilder.java
@@ -39,7 +39,7 @@ public class AppUploaderBuilder extends Builder {
                            @Nonnull BuildListener listener) throws InterruptedException, IOException {
         PrintStream logger = listener.getLogger();
 
-        String appId = AppUploaderHelper.uploadApp(build, logger, this.buildFilePath);
+        String appId = AppUploaderHelper.uploadApp(build, logger, this.buildFilePath, null);
 
         if (StringUtils.isEmpty(appId)) {
             return false;

--- a/src/main/java/com/browserstack/automate/ci/jenkins/AutomateTestAction.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/AutomateTestAction.java
@@ -1,11 +1,9 @@
 package com.browserstack.automate.ci.jenkins;
 
-import com.browserstack.appautomate.AppAutomateClient;
-import com.browserstack.automate.AutomateClient;
 import com.browserstack.automate.ci.common.analytics.Analytics;
+import com.browserstack.automate.ci.common.clienthandler.ClientHandler;
 import com.browserstack.automate.ci.common.enums.ProjectType;
 import com.browserstack.automate.ci.common.model.BrowserStackSession;
-import com.browserstack.automate.ci.common.proxysettings.JenkinsProxySettings;
 import com.browserstack.automate.ci.jenkins.BrowserStackBuildWrapper.BuildWrapperItem;
 import com.browserstack.automate.exception.AppAutomateException;
 import com.browserstack.automate.exception.AutomateException;
@@ -106,16 +104,8 @@ public class AutomateTestAction extends TestAction {
 
     private Session getSession(BrowserStackCredentials credentials, ProjectType projectType) {
         Session activeSession = null;
-        BrowserStackClient client = null;
-        if (projectType.equals(ProjectType.APP_AUTOMATE)) {
-            client =
-                    new AppAutomateClient(credentials.getUsername(), credentials.getDecryptedAccesskey());
-        } else {
-            client = new AutomateClient(credentials.getUsername(), credentials.getDecryptedAccesskey());
-        }
-        if (JenkinsProxySettings.hasProxy()) {
-            client.setProxy(JenkinsProxySettings.getHost(), JenkinsProxySettings.getPort(), JenkinsProxySettings.getUsername(), JenkinsProxySettings.getPassword());
-        }
+        BrowserStackClient client = ClientHandler.getBrowserStackClient(projectType, credentials.getUsername(),
+                credentials.getDecryptedAccesskey(), null, null);
         try {
             activeSession = client.getSession(this.browserStackSession.getSessionId());
             Analytics.trackIframeRequest();

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCredentials.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCredentials.java
@@ -2,7 +2,8 @@ package com.browserstack.automate.ci.jenkins;
 
 import com.browserstack.automate.AutomateClient;
 import com.browserstack.automate.ci.common.analytics.Analytics;
-import com.browserstack.automate.ci.common.proxysettings.JenkinsProxySettings;
+import com.browserstack.automate.ci.common.clienthandler.ClientHandler;
+import com.browserstack.automate.ci.common.enums.ProjectType;
 import com.browserstack.automate.exception.AutomateException;
 import com.cloudbees.plugins.credentials.BaseCredentials;
 import com.cloudbees.plugins.credentials.CredentialsDescriptor;
@@ -72,11 +73,8 @@ public class BrowserStackCredentials extends BaseCredentials implements Standard
         }
 
         try {
-            AutomateClient client = new AutomateClient(username, accesskey);
-            System.out.println("Inside BrowserStackCredentials....");
-//            if (JenkinsProxySettings.hasProxy()) {
-//                client.setProxy(JenkinsProxySettings.getHost(), JenkinsProxySettings.getPort(), JenkinsProxySettings.getUsername(), JenkinsProxySettings.getPassword());
-//            }
+            AutomateClient client =
+                    (AutomateClient) ClientHandler.getBrowserStackClient(ProjectType.AUTOMATE, username, accesskey, null, null);
             if (client.getAccountUsage() != null) {
                 return FormValidation.ok(OK_VALID_AUTH);
             }

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCredentials.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCredentials.java
@@ -73,9 +73,10 @@ public class BrowserStackCredentials extends BaseCredentials implements Standard
 
         try {
             AutomateClient client = new AutomateClient(username, accesskey);
-            if (JenkinsProxySettings.hasProxy()) {
-                client.setProxy(JenkinsProxySettings.getHost(), JenkinsProxySettings.getPort(), JenkinsProxySettings.getUsername(), JenkinsProxySettings.getPassword());
-            }
+            System.out.println("Inside BrowserStackCredentials....");
+//            if (JenkinsProxySettings.hasProxy()) {
+//                client.setProxy(JenkinsProxySettings.getHost(), JenkinsProxySettings.getPort(), JenkinsProxySettings.getUsername(), JenkinsProxySettings.getPassword());
+//            }
             if (client.getAccountUsage() != null) {
                 return FormValidation.ok(OK_VALID_AUTH);
             }

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
@@ -82,7 +82,6 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
         }
 
         tracker.setCredentials(credentials.getUsername(), credentials.getDecryptedAccesskey());
-        log(logger, "Credentials used: " + credentials.getUsername() + ", " + credentials.getDecryptedAccesskey());
 
         BrowserStackClient client =
                 ClientHandler.getBrowserStackClient(projectType, credentials.getUsername(), credentials.getDecryptedAccesskey(), customProxy, logger);

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
@@ -1,11 +1,9 @@
 package com.browserstack.automate.ci.jenkins;
 
-import com.browserstack.appautomate.AppAutomateClient;
-import com.browserstack.automate.AutomateClient;
 import com.browserstack.automate.ci.common.Tools;
+import com.browserstack.automate.ci.common.clienthandler.ClientHandler;
 import com.browserstack.automate.ci.common.constants.Constants;
 import com.browserstack.automate.ci.common.enums.ProjectType;
-import com.browserstack.automate.ci.common.proxysettings.JenkinsProxySettings;
 import com.browserstack.automate.ci.common.tracking.PluginsTracker;
 import com.browserstack.automate.exception.BuildNotFound;
 import com.browserstack.automate.model.Build;
@@ -28,6 +26,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
+import static com.browserstack.automate.ci.common.logger.PluginLogger.log;
 import static com.browserstack.automate.ci.common.logger.PluginLogger.logError;
 
 public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBuild {
@@ -37,6 +36,7 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
     private final Map<String, String> resultAggregation;
     private final ProjectType projectType;
     private final transient PrintStream logger;
+    private final String customProxy;
     private final PluginsTracker tracker;
     private final boolean pipelineStatus;
     // to make them available in jelly
@@ -50,7 +50,8 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
                                       final String buildName,
                                       final PrintStream logger,
                                       final PluginsTracker tracker,
-                                      final boolean pipelineStatus) {
+                                      final boolean pipelineStatus,
+                                      final String customProxy) {
         super();
         setBuild(build);
         this.buildName = buildName;
@@ -59,6 +60,7 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
         this.resultAggregation = new HashMap<>();
         this.projectType = projectType;
         this.logger = logger;
+        this.customProxy = customProxy;
         this.tracker = tracker;
         this.pipelineStatus = pipelineStatus;
         fetchBuildAndSessions();
@@ -80,16 +82,10 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
         }
 
         tracker.setCredentials(credentials.getUsername(), credentials.getDecryptedAccesskey());
+        log(logger, "Credentials used: " + credentials.getUsername() + ", " + credentials.getDecryptedAccesskey());
 
-        BrowserStackClient client;
-        if (projectType == ProjectType.APP_AUTOMATE) {
-            client = new AppAutomateClient(credentials.getUsername(), credentials.getDecryptedAccesskey());
-        } else {
-            client = new AutomateClient(credentials.getUsername(), credentials.getDecryptedAccesskey());
-        }
-        if (JenkinsProxySettings.hasProxy()) {
-            client.setProxy(JenkinsProxySettings.getHost(), JenkinsProxySettings.getPort(), JenkinsProxySettings.getUsername(), JenkinsProxySettings.getPassword());
-        }
+        BrowserStackClient client =
+                ClientHandler.getBrowserStackClient(projectType, credentials.getUsername(), credentials.getDecryptedAccesskey(), customProxy, logger);
 
         browserStackBuild = fetchBrowserStackBuild(client, buildName);
 

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
@@ -61,7 +61,6 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
         this.projectType = projectType;
         this.logger = logger;
         this.customProxy = customProxy;
-        System.out.println("Initialized BrowserStackReportForBuild with customProxy: " + this.customProxy);
         this.tracker = tracker;
         this.pipelineStatus = pipelineStatus;
         fetchBuildAndSessions();

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportForBuild.java
@@ -37,7 +37,7 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
     private final ProjectType projectType;
     private final transient PrintStream logger;
     private final String customProxy;
-    private final PluginsTracker tracker;
+    private final transient PluginsTracker tracker;
     private final boolean pipelineStatus;
     // to make them available in jelly
     private final String errorConst = Constants.SessionStatus.ERROR;
@@ -61,6 +61,7 @@ public class BrowserStackReportForBuild extends AbstractBrowserStackReportForBui
         this.projectType = projectType;
         this.logger = logger;
         this.customProxy = customProxy;
+        System.out.println("Initialized BrowserStackReportForBuild with customProxy: " + this.customProxy);
         this.tracker = tracker;
         this.pipelineStatus = pipelineStatus;
         fetchBuildAndSessions();

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportPublisher.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackReportPublisher.java
@@ -58,7 +58,7 @@ public class BrowserStackReportPublisher extends Recorder implements SimpleBuild
         log(logger, "BrowserStack Project identified as : " + product.name());
 
         final BrowserStackReportForBuild bstackReportAction =
-                new BrowserStackReportForBuild(build, product, browserStackBuildName, logger, tracker, pipelineStatus);
+                new BrowserStackReportForBuild(build, product, browserStackBuildName, logger, tracker, pipelineStatus, null);
         final boolean reportResult = bstackReportAction.generateBrowserStackReport();
         build.addAction(bstackReportAction);
 

--- a/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/local/JenkinsBrowserStackLocal.java
@@ -64,7 +64,6 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
                     localIdentifier = args[i + 1];
                     if (StringUtils.isNotBlank(localIdentifier)) {
                         localIdentifierOverriden = true;
-                        continue;
                     }
 
                     // skip next, since already processed
@@ -84,11 +83,14 @@ public class JenkinsBrowserStackLocal extends Local implements Serializable {
 
             arguments.add(args[i]);
         }
+
         if (!localIdentifierOverriden) {
             localIdentifier = UUID.randomUUID().toString() + "-" + buildTag.replaceAll("[^\\w\\-\\.]", "_");
-            arguments.add(localIdPos, localIdentifier);
-            arguments.add(localIdPos, "-" + OPTION_LOCAL_IDENTIFIER);
         }
+
+        arguments.add(localIdPos, localIdentifier);
+        arguments.add(localIdPos, "-" + OPTION_LOCAL_IDENTIFIER);
+
         return arguments.toArray(new String[]{});
     }
 

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
 import java.io.PrintStream;
 import java.util.HashMap;
+import java.util.Optional;
 
 public class AppUploadStepExecution extends SynchronousNonBlockingStepExecution<Void> {
 
@@ -34,8 +35,12 @@ public class AppUploadStepExecution extends SynchronousNonBlockingStepExecution<
         Run run = context.get(Run.class);
         TaskListener taskListener = context.get(TaskListener.class);
         PrintStream logger = taskListener.getLogger();
+        EnvVars parentContextEnvVars = context.get(EnvVars.class);
 
-        String appId = AppUploaderHelper.uploadApp(run, logger, this.appPath);
+        String customProxy = parentContextEnvVars.get("https_proxy");
+        customProxy = Optional.ofNullable(customProxy).orElse(parentContextEnvVars.get("http_proxy"));
+
+        String appId = AppUploaderHelper.uploadApp(run, logger, this.appPath, customProxy);
 
         if (StringUtils.isEmpty(appId)) {
             PluginLogger.log(logger, "ERROR : App Id empty. ABORTING!!!");

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
@@ -40,7 +40,6 @@ public class AppUploadStepExecution extends SynchronousNonBlockingStepExecution<
         String customProxy = parentContextEnvVars.get("https_proxy");
         customProxy = Optional.ofNullable(customProxy).orElse(parentContextEnvVars.get("http_proxy"));
 
-        System.out.println("App upload custom proxy: " + customProxy);
         String appId = AppUploaderHelper.uploadApp(run, logger, this.appPath, customProxy);
 
         if (StringUtils.isEmpty(appId)) {

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/AppUploadStepExecution.java
@@ -40,6 +40,7 @@ public class AppUploadStepExecution extends SynchronousNonBlockingStepExecution<
         String customProxy = parentContextEnvVars.get("https_proxy");
         customProxy = Optional.ofNullable(customProxy).orElse(parentContextEnvVars.get("http_proxy"));
 
+        System.out.println("App upload custom proxy: " + customProxy);
         String appId = AppUploaderHelper.uploadApp(run, logger, this.appPath, customProxy);
 
         if (StringUtils.isEmpty(appId)) {

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -21,6 +21,7 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.HashMap;
+import java.util.Optional;
 
 import static com.browserstack.automate.ci.common.logger.PluginLogger.log;
 import static com.browserstack.automate.ci.common.logger.PluginLogger.logError;
@@ -47,7 +48,14 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
         TaskListener taskListener = context.get(TaskListener.class);
         Launcher launcher = context.get(Launcher.class);
         PrintStream logger = taskListener.getLogger();
-        PluginsTracker tracker = new PluginsTracker();
+        EnvVars parentContextEnvVars = context.get(EnvVars.class);
+
+        String customProxy = parentContextEnvVars.get("https_proxy");
+        customProxy = Optional.ofNullable(customProxy).orElse(parentContextEnvVars.get("http_proxy"));
+
+        final PluginsTracker tracker = new PluginsTracker(customProxy);
+
+        System.out.println("\ncustomProxy: " + customProxy);
 
         BrowserStackCredentials credentials =
                 BrowserStackCredentials.getCredentials(run.getParent(), credentialsId);

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -55,7 +55,7 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
 
         final PluginsTracker tracker = new PluginsTracker(customProxy);
 
-        System.out.println("\ncustomProxy: " + customProxy);
+        System.out.println("\ncustomProxy in pipeline execution: " + customProxy);
 
         BrowserStackCredentials credentials =
                 BrowserStackCredentials.getCredentials(run.getParent(), credentialsId);

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -55,8 +55,6 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
 
         final PluginsTracker tracker = new PluginsTracker(customProxy);
 
-        System.out.println("\ncustomProxy in pipeline execution: " + customProxy);
-
         BrowserStackCredentials credentials =
                 BrowserStackCredentials.getCredentials(run.getParent(), credentialsId);
 

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackReportStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackReportStepExecution.java
@@ -38,8 +38,6 @@ public class BrowserStackReportStepExecution extends SynchronousNonBlockingStepE
 
         final PluginsTracker tracker = new PluginsTracker(customProxy);
 
-        System.out.println("\ncustomProxy in report generation: " + customProxy);
-
         log(logger, "Generating BrowserStack Test Report via Pipeline for : " + product.name());
 
         String browserStackBuildName = parentContextEnvVars.get(BrowserStackEnvVars.BROWSERSTACK_BUILD_NAME);


### PR DESCRIPTION
Task: https://browserstack.atlassian.net/browse/ACE-1568 

Changes:
1. Requests from the plugin for new-report generation will honor the proxy settings now. And the respective related components.
2. Priority of proxy settings:
a. `https_proxy` and `http_proxy` set via `withEnv` in Pipeline script
b. `https_proxy` and `http_proxy` set in System level, retrieved using `System.getenv`
c. Jenkins Proxy configuration
d. JAR arguments, i.e. `https.proxyHost, https.proxyPort, https.proxyUser, https.proxyPassword`
3. BrowserStack Local not honoring custom local-identifier fix. Task: https://browserstack.atlassian.net/browse/ACE-1754

Related PR for the included changes: https://github.com/browserstack/automate-client-java/pull/8 - To make proxy auth params non-mandatory while reaching out to BrowserStack via the plugin.