### PR TITLE
Add support for Job DSL with and without localConfig key inside browseStackBuildWrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.2.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackBuildWrapper.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackBuildWrapper.java
@@ -19,6 +19,7 @@ import hudson.tasks.BuildWrapper;
 import hudson.util.DescribableList;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -31,15 +32,19 @@ public class BrowserStackBuildWrapper extends BuildWrapper {
 
     private static final char CHAR_MASK = '*';
 
-    private final LocalConfig localConfig;
+    private LocalConfig localConfig;
 
     private String credentialsId;
     private String username;
     private String accesskey;
 
     @DataBoundConstructor
-    public BrowserStackBuildWrapper(String credentialsId, LocalConfig localConfig) {
+    public BrowserStackBuildWrapper(String credentialsId) {
         this.credentialsId = credentialsId;
+    }
+
+    @DataBoundSetter
+    public void setLocalConfig(LocalConfig localConfig) {
         this.localConfig = localConfig;
     }
 

--- a/src/test/java/com/browserstack/automate/ci/jenkins/AutomateTestActionTest.java
+++ b/src/test/java/com/browserstack/automate/ci/jenkins/AutomateTestActionTest.java
@@ -124,7 +124,8 @@ public class AutomateTestActionTest {
         localConfig.setLocalOptions("-force");
 
         BrowserStackBuildWrapper buildWrapper =
-                new BrowserStackBuildWrapper(credentialsId, localConfig);
+                new BrowserStackBuildWrapper(credentialsId);
+        buildWrapper.setLocalConfig(localConfig);
         project.getBuildWrappersList().add(buildWrapper);
     }
 

--- a/src/test/java/com/browserstack/automate/ci/jenkins/AutomateTestDataPublisherTest.java
+++ b/src/test/java/com/browserstack/automate/ci/jenkins/AutomateTestDataPublisherTest.java
@@ -115,7 +115,8 @@ public class AutomateTestDataPublisherTest {
         LocalConfig localConfig = new LocalConfig();
         localConfig.setLocalOptions("-force");
 
-        BrowserStackBuildWrapper buildWrapper = new BrowserStackBuildWrapper(credentialsId, localConfig);
+        BrowserStackBuildWrapper buildWrapper = new BrowserStackBuildWrapper(credentialsId);
+        buildWrapper.setLocalConfig(localConfig);
         project.getBuildWrappersList().add(buildWrapper);
     }
 


### PR DESCRIPTION
Currently in the groovy script the local parameters are required and an error is thrown if absent. Users want to run tests without local as well for which the current changes will make it optional and inside the browserstackBuildWrapper they can exclude localConfig key.