### PR TITLE
added check for getAbsoluteFile

### DIFF
--- a/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploaderHelper.java
+++ b/src/main/java/com/browserstack/automate/ci/common/uploader/AppUploaderHelper.java
@@ -18,7 +18,7 @@ public class AppUploaderHelper {
       return FormValidation.error("Please enter absolute path to your app.");
     }
     File file = new File(appPath);
-    if (!file.exists()) {
+    if (!file.exists() || !file.getAbsoluteFile().exists()) {
       return FormValidation.error("File not found : " + appPath);
     }
 


### PR DESCRIPTION
added check for getAbsoluteFile

<img width="1138" alt="Screenshot 2021-05-22 at 3 59 33 AM" src="https://user-images.githubusercontent.com/6334309/119204129-46d15100-bab2-11eb-9bba-4368988f2785.png">

CURL worked but BS plugin is not able to get the file. Upon investigation it seems to be an issue related to how fileexist check happens. Added check for absolute file path

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
