### PR TITLE
Update separator check to accomodate builds without separator in names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.3-SNAPSHOT</version>
+  <version>1.2.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCypressReportForBuild.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCypressReportForBuild.java
@@ -52,7 +52,7 @@ public class BrowserStackCypressReportForBuild extends AbstractBrowserStackCypre
             String jsonTxt = IOUtils.toString(is, "UTF-8");
             report = new JSONObject(jsonTxt);
         } catch (FileNotFoundException e) {
-            logError(logger, "No BrowserStackBuildAction found");
+            logError(logger, "Cypress report not found at " + reportJSONPath);
             tracker.sendError("BrowserStack Cypress Report Not Found", pipelineStatus, "CypressReportGeneration");
         } catch (IOException e) {
             logError(logger, "There was a problem while reading report files");
@@ -70,7 +70,9 @@ public class BrowserStackCypressReportForBuild extends AbstractBrowserStackCypre
             }
 
             String buildNameWithBuildNumber = matrix.optString("build_name");
-            String buildNameWithoutBuildNumber = buildNameWithBuildNumber.substring(0, buildNameWithBuildNumber.lastIndexOf(": "));
+            int indexOfBuildNumberSeparator = buildNameWithBuildNumber.lastIndexOf(": ") == -1 ? buildNameWithBuildNumber.length()
+                    : buildNameWithBuildNumber.lastIndexOf(": ");
+            String buildNameWithoutBuildNumber = buildNameWithBuildNumber.substring(0, indexOfBuildNumberSeparator);
 
             if (buildNameWithoutBuildNumber == null) {
                 logError(logger, "BrowserStack Cypress Report not generated, result json may have been corrupted. Please retry.");

--- a/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCypressReportPublisher.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/BrowserStackCypressReportPublisher.java
@@ -47,7 +47,7 @@ public class BrowserStackCypressReportPublisher extends Recorder implements Simp
         final EnvVars parentEnvs = build.getEnvironment(listener);
         String browserStackBuildName = parentEnvs.get(BrowserStackEnvVars.BROWSERSTACK_BUILD_NAME);
         browserStackBuildName = Optional.ofNullable(browserStackBuildName).orElse(parentEnvs.get(Constants.JENKINS_BUILD_TAG));
-        final String jenkinsFolder = parentEnvs.get("WORKSPACE");
+        final String jenkinsFolder = parentEnvs.get("BROWSERSTACK_CYPRESS_PROJECT_ROOT") != null ? parentEnvs.get("BROWSERSTACK_CYPRESS_PROJECT_ROOT") : parentEnvs.get("WORKSPACE");
         ProjectType product = ProjectType.AUTOMATE;
 
         tracker.reportGenerationInitialized(browserStackBuildName, product.name(), pipelineStatus);


### PR DESCRIPTION
Plugin would throw error while generating cypress test report if the build name doesn't have the ":" separator in it. Updated the check accordingly.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
