### PR TITLE
remove username environment variable suffix

### DIFF
--- a/src/main/java/com/browserstack/automate/ci/common/BrowserStackBuildWrapperOperations.java
+++ b/src/main/java/com/browserstack/automate/ci/common/BrowserStackBuildWrapperOperations.java
@@ -116,8 +116,8 @@ public class BrowserStackBuildWrapperOperations {
             if (credentials.hasUsername()) {
                 String username = credentials.getUsername();
 
-                env.put(BrowserStackEnvVars.BROWSERSTACK_USER, username + "-jenkins");
-                env.put(BrowserStackEnvVars.BROWSERSTACK_USERNAME, username + "-jenkins");
+                env.put(BrowserStackEnvVars.BROWSERSTACK_USER, username);
+                env.put(BrowserStackEnvVars.BROWSERSTACK_USERNAME, username);
                 logEnvVar(BrowserStackEnvVars.BROWSERSTACK_USERNAME, username);
             }
 


### PR DESCRIPTION
This pull request serves as a suggestion for improvement, as we have a problem with automatically adding the string `-jenkins` to the environment variable `BROWSERSTACK_USER` and `BROWSERSTACK_USERNAME`.

The plugin offers the possibility to store the correct user credentials in Jenkins and to store them in the global configuration of the BrowserStack plugin. I don't understand why the string `-jenkins` is necessary at this point.

Maybe someone can explain me why it was implemented this way.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```