### PR TITLE
Configuring GRR region and API url  through ENV variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.16</version>
+  <version>1.2.17-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.16</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.15</version>
+  <version>1.2.16-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.15</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>com.browserstack</groupId>
       <artifactId>automate-client-java</artifactId>
-      <version>0.12</version>
+      <version>0.12-SNAPSHOT</version>
       <scope>system</scope>
       <systemPath>/Users/hariharan/hari-automate-client/automate-client-java/target/automate-client-java-0.12.jar</systemPath>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.14-SNAPSHOT</version>
+  <version>1.2.14</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.14</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.19-SNAPSHOT</version>
+  <version>1.2.11-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.11-SNAPSHOT</version>
+  <version>1.2.11</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.11</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.17-SNAPSHOT</version>
+  <version>1.2.17</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.17</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 
@@ -150,9 +150,9 @@
     <dependency>
       <groupId>com.browserstack</groupId>
       <artifactId>automate-client-java</artifactId>
-      <version>0.12</version>
-      <scope>system</scope>
-      <systemPath>/Users/hariharan/hari-automate-client/automate-client-java/target/automate-client-java-0.12.jar</systemPath>
+      <version>0.7</version>
+      <!-- <scope>system</scope>
+      <systemPath>/Users/hariharan/hari-automate-client/automate-client-java/target/automate-client-java-0.12.jar</systemPath> -->
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.15-SNAPSHOT</version>
+  <version>1.2.16</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.16</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.13-SNAPSHOT</version>
+  <version>1.2.13</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.13</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 
@@ -150,7 +150,9 @@
     <dependency>
       <groupId>com.browserstack</groupId>
       <artifactId>automate-client-java</artifactId>
-      <version>0.7</version>
+      <version>0.12</version>
+      <scope>system</scope>
+      <systemPath>/Users/hariharan/hari-automate-client/automate-client-java/target/automate-client-java-0.12-SNAPSHOT.jar</systemPath>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.18</version>
+  <version>1.2.19-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.18</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.17</version>
+  <version>1.2.18-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.17</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.13</version>
+  <version>1.2.14-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.13</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.18-SNAPSHOT</version>
+  <version>1.2.18</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.18</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.12</version>
+  <version>1.2.13-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.12</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.16-SNAPSHOT</version>
+  <version>1.2.16</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.16</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>com.browserstack</groupId>
       <artifactId>automate-client-java</artifactId>
-      <version>0.12-SNAPSHOT</version>
+      <version>0.12</version>
       <scope>system</scope>
       <systemPath>/Users/hariharan/hari-automate-client/automate-client-java/target/automate-client-java-0.12.jar</systemPath>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.17-SNAPSHOT</version>
+  <version>1.2.11-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.14</version>
+  <version>1.2.15-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.14</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.12-SNAPSHOT</version>
+  <version>1.2.12</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.12</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.13-SNAPSHOT</version>
+  <version>1.2.13</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.13</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.11</version>
+  <version>1.2.12-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>browserstack-integration-1.2.11</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.11-SNAPSHOT</version>
+  <version>1.2.12</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.12</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>browserstack-integration</artifactId>
-  <version>1.2.15-SNAPSHOT</version>
+  <version>1.2.15</version>
   <packaging>hpi</packaging>
 
   <name>BrowserStack</name>
@@ -34,7 +34,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/browserstack-integration-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/browserstack-integration-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/browserstack-integration-plugin</url>
-    <tag>HEAD</tag>
+    <tag>browserstack-integration-1.2.15</tag>
   </scm>
 
   <!-- Adding a distribution management section here to override the now 
@@ -152,7 +152,7 @@
       <artifactId>automate-client-java</artifactId>
       <version>0.12</version>
       <scope>system</scope>
-      <systemPath>/Users/hariharan/hari-automate-client/automate-client-java/target/automate-client-java-0.12-SNAPSHOT.jar</systemPath>
+      <systemPath>/Users/hariharan/hari-automate-client/automate-client-java/target/automate-client-java-0.12.jar</systemPath>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/browserstack/automate/ci/common/BrowserStackBuildWrapperOperations.java
+++ b/src/main/java/com/browserstack/automate/ci/common/BrowserStackBuildWrapperOperations.java
@@ -1,5 +1,6 @@
 package com.browserstack.automate.ci.common;
 
+import com.browserstack.automate.ci.common.constants.Constants;
 import com.browserstack.automate.ci.jenkins.BrowserStackCredentials;
 import com.browserstack.automate.ci.jenkins.local.JenkinsBrowserStackLocal;
 import com.browserstack.automate.ci.jenkins.local.LocalConfig;
@@ -127,6 +128,14 @@ public class BrowserStackBuildWrapperOperations {
                 env.put(BrowserStackEnvVars.BROWSERSTACK_ACCESS_KEY, accesskey);
                 logEnvVar(BrowserStackEnvVars.BROWSERSTACK_ACCESS_KEY, Tools.maskString(accesskey));
             }
+        }
+
+        if ( env.get(BrowserStackEnvVars.GRR_JENKINS_KEY) != null && !env.get(BrowserStackEnvVars.GRR_JENKINS_KEY).isEmpty() && Constants.GRR_AUTO_REGION_VS_APIURL.containsKey(env.get(BrowserStackEnvVars.GRR_JENKINS_KEY).toLowerCase()) ) {
+            logEnvVar(BrowserStackEnvVars.GRR_JENKINS_KEY, env.get(BrowserStackEnvVars.GRR_JENKINS_KEY));
+            System.setProperty(BrowserStackEnvVars.AUTOMATE_API_ENV_KEY, Constants.GRR_AUTO_REGION_VS_APIURL.get(env.get(BrowserStackEnvVars.GRR_JENKINS_KEY).toLowerCase()));
+            System.setProperty(BrowserStackEnvVars.APP_AUTOMATE_API_ENV_KEY, Constants.GRR_APPAUTO_REGION_VS_APIURL.get(env.get(BrowserStackEnvVars.GRR_JENKINS_KEY).toLowerCase()));
+            logEnvVar(BrowserStackEnvVars.AUTOMATE_API_ENV_KEY.toUpperCase(), Constants.GRR_AUTO_REGION_VS_APIURL.get(env.get(BrowserStackEnvVars.GRR_JENKINS_KEY).toLowerCase()));
+            logEnvVar(BrowserStackEnvVars.APP_AUTOMATE_API_ENV_KEY.toUpperCase(), Constants.GRR_APPAUTO_REGION_VS_APIURL.get(env.get(BrowserStackEnvVars.GRR_JENKINS_KEY).toLowerCase()));
         }
 
         String buildTag = env.get(ENV_JENKINS_BUILD_TAG);

--- a/src/main/java/com/browserstack/automate/ci/common/BrowserStackBuildWrapperOperations.java
+++ b/src/main/java/com/browserstack/automate/ci/common/BrowserStackBuildWrapperOperations.java
@@ -131,12 +131,15 @@ public class BrowserStackBuildWrapperOperations {
         }
 
         String grr_region = env.get(BrowserStackEnvVars.GRR_JENKINS_KEY);
-        if ( grr_region != null && Constants.GRR_AUTO_REGION_VS_APIURL.containsKey(grr_region.toLowerCase()) ) {
+        if ( grr_region != null ) {
             logEnvVar(BrowserStackEnvVars.GRR_JENKINS_KEY, grr_region);
-            System.setProperty(BrowserStackEnvVars.AUTOMATE_API_ENV_KEY, Constants.GRR_AUTO_REGION_VS_APIURL.get(grr_region.toLowerCase()));
-            System.setProperty(BrowserStackEnvVars.APP_AUTOMATE_API_ENV_KEY, Constants.GRR_APPAUTO_REGION_VS_APIURL.get(grr_region.toLowerCase()));
-            logEnvVar(BrowserStackEnvVars.AUTOMATE_API_ENV_KEY.toUpperCase(), Constants.GRR_AUTO_REGION_VS_APIURL.get(grr_region.toLowerCase()));
-            logEnvVar(BrowserStackEnvVars.APP_AUTOMATE_API_ENV_KEY.toUpperCase(), Constants.GRR_APPAUTO_REGION_VS_APIURL.get(grr_region.toLowerCase()));
+            if ( Constants.GRR_AUTO_REGION_VS_APIURL.containsKey(grr_region.toLowerCase()) ) {
+                setSystemProperty(BrowserStackEnvVars.AUTOMATE_API_ENV_KEY, Constants.GRR_AUTO_REGION_VS_APIURL.get(grr_region.toLowerCase()));
+                setSystemProperty(BrowserStackEnvVars.APP_AUTOMATE_API_ENV_KEY, Constants.GRR_APPAUTO_REGION_VS_APIURL.get(grr_region.toLowerCase()));
+            }
+            else {
+                log(logger, "Invalid GRR REGION passed. Supported values are US, EU. Skipping GRR Region for this job.");
+            }
         }
 
         String buildTag = env.get(ENV_JENKINS_BUILD_TAG);
@@ -190,4 +193,12 @@ public class BrowserStackBuildWrapperOperations {
             log(logger, key + "=" + value);
         }
     }
+
+    public void setSystemProperty(String key, String value) {
+        if(key != null){
+            System.setProperty(key, value);
+            logEnvVar(key.toUpperCase(), value);
+        }
+    }
+
 }

--- a/src/main/java/com/browserstack/automate/ci/common/BrowserStackEnvVars.java
+++ b/src/main/java/com/browserstack/automate/ci/common/BrowserStackEnvVars.java
@@ -12,4 +12,7 @@ public interface BrowserStackEnvVars {
     String BROWSERSTACK_APP_ID = "BROWSERSTACK_APP_ID";
     String BROWSERSTACK_RERUN = "BROWSERSTACK_RERUN";
     String BROWSERSTACK_RERUN_TESTS = "BROWSERSTACK_RERUN_TESTS";
+    String GRR_JENKINS_KEY = "BROWSERSTACK_GRR_REGION";
+    String AUTOMATE_API_ENV_KEY = "browserstack.automate.api";
+    String APP_AUTOMATE_API_ENV_KEY = "browserstack.app-automate.api";
 }

--- a/src/main/java/com/browserstack/automate/ci/common/constants/Constants.java
+++ b/src/main/java/com/browserstack/automate/ci/common/constants/Constants.java
@@ -1,5 +1,8 @@
 package com.browserstack.automate.ci.common.constants;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import jenkins.model.Jenkins;
 
 public class Constants {
@@ -15,10 +18,16 @@ public class Constants {
     // Product
     public static final String AUTOMATE = "automate";
     public static final String APP_AUTOMATE = "app-automate";
-    public static final String AUTOMATE_API_ENV_KEY = "browserstack.automate.api";
-    public static final String APP_AUTOMATE_API_ENV_KEY = "browserstack.app-automate.api";
-    public static final String AUTOMATE_API_JENKINS_KEY = "BROWSERSTACK_AUTOMATE_API_URL";
-    public static final String APP_AUTOMATE_API_JENKINS_KEY = "BROWSERSTACK_APPAUTOMATE_API_URL";
+
+    //GRR REGION vs API URL mapping for Automate
+    public static Map<String, String> GRR_AUTO_REGION_VS_APIURL = new HashMap<String, String>();
+    public static Map<String, String> GRR_APPAUTO_REGION_VS_APIURL = new HashMap<String, String>();
+    static {
+        GRR_AUTO_REGION_VS_APIURL.put("eu","https://api-eu-only.browserstack.com/automate");
+        GRR_AUTO_REGION_VS_APIURL.put("us","https://api-us-only.browserstack.com/automate");
+        GRR_APPAUTO_REGION_VS_APIURL.put("eu","https://api-eu-only.browserstack.com/app-automate");
+        GRR_APPAUTO_REGION_VS_APIURL.put("us","https://api-us-only.browserstack.com/app-automate");
+    }
 
     public static final String JENKINS_BUILD_TAG = "BUILD_TAG";
 

--- a/src/main/java/com/browserstack/automate/ci/common/constants/Constants.java
+++ b/src/main/java/com/browserstack/automate/ci/common/constants/Constants.java
@@ -17,6 +17,8 @@ public class Constants {
     public static final String APP_AUTOMATE = "app-automate";
     public static final String AUTOMATE_API_ENV_KEY = "browserstack.automate.api";
     public static final String APP_AUTOMATE_API_ENV_KEY = "browserstack.app-automate.api";
+    public static final String AUTOMATE_API_JENKINS_KEY = "BROWSERSTACK_AUTOMATE_API_URL";
+    public static final String APP_AUTOMATE_API_JENKINS_KEY = "BROWSERSTACK_APPAUTOMATE_API_URL";
 
     public static final String JENKINS_BUILD_TAG = "BUILD_TAG";
 

--- a/src/main/java/com/browserstack/automate/ci/common/constants/Constants.java
+++ b/src/main/java/com/browserstack/automate/ci/common/constants/Constants.java
@@ -15,6 +15,8 @@ public class Constants {
     // Product
     public static final String AUTOMATE = "automate";
     public static final String APP_AUTOMATE = "app-automate";
+    public static final String AUTOMATE_API_ENV_KEY = "browserstack.automate.api";
+    public static final String APP_AUTOMATE_API_ENV_KEY = "browserstack.app-automate.api";
 
     public static final String JENKINS_BUILD_TAG = "BUILD_TAG";
 

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -99,6 +99,14 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
         EnvVars overrides = run.getEnvironment(taskListener);
         HashMap<String, String> overridesMap = new HashMap<String, String>();
         overridesMap.put(Constants.JENKINS_BUILD_TAG, overrides.get(Constants.JENKINS_BUILD_TAG));
+        if(parentContextEnvVars.containsKey(Constants.AUTOMATE_API_ENV_KEY)){
+            log(logger, "Setting Automate API URL to "+parentContextEnvVars.get(Constants.AUTOMATE_API_ENV_KEY));
+            System.setProperty(Constants.AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.AUTOMATE_API_ENV_KEY));
+        }
+        if(parentContextEnvVars.containsKey(Constants.APP_AUTOMATE_API_ENV_KEY)){
+            log(logger, "Setting App Automate API URL to "+parentContextEnvVars.get(Constants.APP_AUTOMATE_API_ENV_KEY));
+            System.setProperty(Constants.APP_AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.APP_AUTOMATE_API_ENV_KEY));
+        }
         buildWrapperOperations.buildEnvVars(overridesMap);
 
         body = getContext()

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -99,13 +99,13 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
         EnvVars overrides = run.getEnvironment(taskListener);
         HashMap<String, String> overridesMap = new HashMap<String, String>();
         overridesMap.put(Constants.JENKINS_BUILD_TAG, overrides.get(Constants.JENKINS_BUILD_TAG));
-        if(parentContextEnvVars.containsKey(Constants.AUTOMATE_API_ENV_KEY)){
-            log(logger, "Setting Automate API URL to "+parentContextEnvVars.get(Constants.AUTOMATE_API_ENV_KEY));
-            System.setProperty(Constants.AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.AUTOMATE_API_ENV_KEY));
+        if(parentContextEnvVars.containsKey(Constants.AUTOMATE_API_JENKINS_KEY)){
+            log(logger, "Setting Automate API URL to "+parentContextEnvVars.get(Constants.AUTOMATE_API_JENKINS_KEY));
+            System.setProperty(Constants.AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.AUTOMATE_API_JENKINS_KEY));
         }
-        if(parentContextEnvVars.containsKey(Constants.APP_AUTOMATE_API_ENV_KEY)){
-            log(logger, "Setting App Automate API URL to "+parentContextEnvVars.get(Constants.APP_AUTOMATE_API_ENV_KEY));
-            System.setProperty(Constants.APP_AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.APP_AUTOMATE_API_ENV_KEY));
+        if(parentContextEnvVars.containsKey(Constants.APP_AUTOMATE_API_JENKINS_KEY)){
+            log(logger, "Setting App Automate API URL to "+parentContextEnvVars.get(Constants.APP_AUTOMATE_API_JENKINS_KEY));
+            System.setProperty(Constants.APP_AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.APP_AUTOMATE_API_JENKINS_KEY));
         }
         buildWrapperOperations.buildEnvVars(overridesMap);
 

--- a/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
+++ b/src/main/java/com/browserstack/automate/ci/jenkins/pipeline/BrowserStackPipelineStepExecution.java
@@ -2,6 +2,7 @@ package com.browserstack.automate.ci.jenkins.pipeline;
 
 import com.browserstack.automate.ci.common.BrowserStackBuildWrapperOperations;
 import com.browserstack.automate.ci.common.constants.Constants;
+import com.browserstack.automate.ci.common.BrowserStackEnvVars;
 import com.browserstack.automate.ci.common.tracking.PluginsTracker;
 import com.browserstack.automate.ci.jenkins.BrowserStackBuildAction;
 import com.browserstack.automate.ci.jenkins.BrowserStackCredentials;
@@ -99,13 +100,8 @@ public class BrowserStackPipelineStepExecution extends StepExecution {
         EnvVars overrides = run.getEnvironment(taskListener);
         HashMap<String, String> overridesMap = new HashMap<String, String>();
         overridesMap.put(Constants.JENKINS_BUILD_TAG, overrides.get(Constants.JENKINS_BUILD_TAG));
-        if(parentContextEnvVars.containsKey(Constants.AUTOMATE_API_JENKINS_KEY)){
-            log(logger, "Setting Automate API URL to "+parentContextEnvVars.get(Constants.AUTOMATE_API_JENKINS_KEY));
-            System.setProperty(Constants.AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.AUTOMATE_API_JENKINS_KEY));
-        }
-        if(parentContextEnvVars.containsKey(Constants.APP_AUTOMATE_API_JENKINS_KEY)){
-            log(logger, "Setting App Automate API URL to "+parentContextEnvVars.get(Constants.APP_AUTOMATE_API_JENKINS_KEY));
-            System.setProperty(Constants.APP_AUTOMATE_API_ENV_KEY, parentContextEnvVars.get(Constants.APP_AUTOMATE_API_JENKINS_KEY));
+        if ( parentContextEnvVars.containsKey(BrowserStackEnvVars.GRR_JENKINS_KEY) ) {
+            overridesMap.put(BrowserStackEnvVars.GRR_JENKINS_KEY, parentContextEnvVars.get(BrowserStackEnvVars.GRR_JENKINS_KEY));
         }
         buildWrapperOperations.buildEnvVars(overridesMap);
 


### PR DESCRIPTION
Description:
- Automate Client Initialisation is done through - https://github.com/browserstack/automate-client-java/blob/master/src/main/java/com/browserstack/automate/AutomateClient.java#L37:L39 . Similar for App Automate Client through AppAutomateClient's constructor.
- This currently expects the system property, which is actually not configurable through jenkins plugin.
- This is needed to be configurable as the GRR customers are intended to use regional domains instead of default domains.
- This PR is aimed to set the system property based on the jenkins environmental variables passed.
- Tested on local jenkins and noticed the new api has been hit with the env set urls.

JIRA:
- https://browserstack.atlassian.net/browse/AFD-2994

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
